### PR TITLE
Resolve shared mutable default

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -254,6 +254,12 @@ class Schedule(models.Model):
 def generate_key():
     return binascii.hexlify(os.urandom(20)).decode()
 
+def load_usersettings():
+    with open(
+        os.path.join(Path(__file__).parent.absolute(), "migrations/usersettings.json"),
+        "r",
+    ) as fh:
+        return json.load(fh)
 
 class UserSettings(models.Model):
     """
@@ -270,7 +276,7 @@ class UserSettings(models.Model):
     )
     token = models.CharField(max_length=40)
     created = models.DateTimeField(auto_now_add=True)
-    settings = models.JSONField(default=data)
+    settings = models.JSONField(default=default_usersettings)
     salt_permissions = models.TextField()
 
     def generate_token(self):

--- a/api/models.py
+++ b/api/models.py
@@ -265,12 +265,7 @@ class UserSettings(models.Model):
     """
     The default authorization token model.
     """
-
-    with open(
-        os.path.join(Path(__file__).parent.absolute(), "migrations/usersettings.json"),
-        "r",
-    ) as fh:
-        data = json.load(fh)
+    
     user = models.OneToOneField(
         User, primary_key=True, related_name="user_settings", on_delete=models.CASCADE
     )


### PR DESCRIPTION
Resolve the following django error:

WARNINGS:
api.UserSettings.settings: (fields.E010) JSONField default should be a callable instead of an instance so that it's not shared between all field instances.
HINT: Use a callable instead, e.g., use dict instead of {}.